### PR TITLE
Support revisions

### DIFF
--- a/argo.routing.yml
+++ b/argo.routing.yml
@@ -33,10 +33,22 @@ argo.reset_deletion_log:
     no_cache: TRUE
 
 argo.export:
-  path: /argo/content-entity/{type}/{uuid}/export/{revisionId}
+  path: /argo/content-entity/{type}/{uuid}/export
   defaults:
     _title: 'Export content entity for translation'
     _controller: '\Drupal\argo\Controller\ArgoController::exportContentEntity'
+  requirements:
+    _format: 'json'
+    _permission: 'translate content using argo'
+  methods: ['GET']
+  options:
+    no_cache: TRUE
+
+argo.export_revision:
+  path: /argo/content-entity/{type}/{uuid}/export/{revisionId}
+  defaults:
+    _title: 'Export content entity revision for translation'
+    _controller: '\Drupal\argo\Controller\ArgoController::exportContentEntityRevision'
   requirements:
     _format: 'json'
     _permission: 'translate content using argo'

--- a/argo.routing.yml
+++ b/argo.routing.yml
@@ -33,7 +33,7 @@ argo.reset_deletion_log:
     no_cache: TRUE
 
 argo.export:
-  path: /argo/content-entity/{type}/{uuid}/export
+  path: /argo/content-entity/{type}/{uuid}/export/{revision_id}
   defaults:
     _title: 'Export content entity for translation'
     _controller: '\Drupal\argo\Controller\ArgoController::exportContentEntity'

--- a/argo.routing.yml
+++ b/argo.routing.yml
@@ -33,7 +33,7 @@ argo.reset_deletion_log:
     no_cache: TRUE
 
 argo.export:
-  path: /argo/content-entity/{type}/{uuid}/export/{revision_id}
+  path: /argo/content-entity/{type}/{uuid}/export/{revisionId}
   defaults:
     _title: 'Export content entity for translation'
     _controller: '\Drupal\argo\Controller\ArgoController::exportContentEntity'

--- a/src/ArgoService.php
+++ b/src/ArgoService.php
@@ -5,6 +5,7 @@ namespace Drupal\argo;
 use Drupal\content_moderation\ModerationInformationInterface;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Database\Database;
+use Drupal\Core\Entity\EntityChangedInterface;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityPublishedInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
@@ -12,6 +13,8 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\Sql\TableMappingInterface;
 use Drupal\Core\Language\Language;
 use Drupal\Core\TypedData\Exception\MissingDataException;
+use Drupal\paragraphs\ParagraphInterface;
+use Drupal\user\EntityOwnerInterface;
 
 /**
  * Interacts with Argo.
@@ -99,6 +102,8 @@ class ArgoService implements ArgoServiceInterface {
    *   Entity type ID.
    * @param string $uuid
    *   Entity UUID.
+   * @param int $revision_id
+   *   (optional) Entity revision ID.
    *
    * @return array
    *   Export.
@@ -107,15 +112,8 @@ class ArgoService implements ArgoServiceInterface {
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
-  public function export(string $entityType, string $uuid) {
-    $loadResult = $this->entityTypeManager
-      ->getStorage($entityType)
-      ->loadByProperties(['uuid' => $uuid]);
-    if (empty($loadResult)) {
-      throw new MissingDataException();
-    }
-    $entity = $loadResult[array_keys($loadResult)[0]];
-
+  public function export(string $entityType, string $uuid, int $revision_id = NULL) {
+    $entity = $this->loadEntity($entityType, $uuid, $revision_id);
     return $this->contentEntityExport->export($entity);
   }
 
@@ -137,18 +135,13 @@ class ArgoService implements ArgoServiceInterface {
    * @throws \Drupal\typed_data\Exception\InvalidArgumentException
    */
   public function translate(string $entityType, string $uuid, array $translation) {
-    $loadResult = $this->entityTypeManager
-      ->getStorage($entityType)
-      ->loadByProperties(['uuid' => $uuid]);
-    if (empty($loadResult)) {
-      throw new MissingDataException();
-    }
-    /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
-    $entity = $loadResult[array_keys($loadResult)[0]];
-
+    $revision_id = $translation['revisionId'] ?? NULL;
+    $entity = $this->loadEntity($entityType, $uuid, $revision_id);
     $translated = $this->contentEntityTranslate->translate($entity, $translation);
 
-    if ($translated instanceof EntityPublishedInterface) {
+    // Paragraphs are never displayed on their own, and so we should not apply
+    // moderation states to these entities.
+    if ($translated instanceof EntityPublishedInterface && !($translated instanceof ParagraphInterface)) {
       $translated->setUnpublished();
     }
     if (isset($translation['stateId'])) {
@@ -167,7 +160,61 @@ class ArgoService implements ArgoServiceInterface {
       }
       $translated->set('moderation_state', $stateId);
     }
+
+    // Update changed time of the entity so we are not saving new revisions with
+    // timestamps in the past.
+    if ($translated instanceof EntityChangedInterface) {
+      $translated->setChangedTime(time());
+    }
+    // Also update the author to reflect the Argo service account.
+    if ($translated instanceof EntityOwnerInterface) {
+      $current_user = \Drupal::currentUser();
+      $translated->setOwnerId($current_user->id());
+    }
     $translated->save();
+  }
+
+  /**
+   * Loads an entity by its uuid or revision Id - if available.
+   *
+   * @param string $entityType
+   *   Entity type ID.
+   * @param string $uuid
+   *   Entity UUID.
+   *
+   * @param int|null $revision_id
+   *
+   * @return \Drupal\Core\Entity\ContentEntityInterface
+   *   The loaded entity.
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   * @throws \Drupal\Core\TypedData\Exception\MissingDataException
+   */
+  private function loadEntity(string $entityType, string $uuid, int $revision_id = NULL) {
+    // Unfortunately loading an entity by its uuid will only load the latest
+    // "published" revision which could be different from the original entity.
+    // Until Drupal core supports loading entity revisions by a uuid, we try and
+    // load the entity by its revision id.
+    // @see https://www.drupal.org/project/drupal/issues/1812202
+    if (isset($revision_id)) {
+      /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
+      $entity = $this->entityTypeManager
+        ->getStorage($entityType)
+        ->loadRevision($revision_id);
+    } else {
+      // If the revision id is not available, we resort to the uuid. Some
+      // entities might not support revisions.
+      $loadResult = $this->entityTypeManager
+        ->getStorage($entityType)
+        ->loadByProperties(['uuid' => $uuid]);
+      if (empty($loadResult)) {
+        throw new MissingDataException();
+      }
+      /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
+      $entity = $loadResult[array_keys($loadResult)[0]];
+    }
+
+    return $entity;
   }
 
   /**
@@ -246,6 +293,7 @@ class ArgoService implements ArgoServiceInterface {
         'typeId' => $entity->getEntityTypeId(),
         'bundle' => $entity->bundle(),
         'id' => $entity->id(),
+        'revisionId' => $entity->getRevisionId(),
         'uuid' => $entity->uuid(),
         'path' => $entity->toUrl()->toString(),
         'langcode' => $entity->language()->getId(),

--- a/src/ArgoService.php
+++ b/src/ArgoService.php
@@ -297,7 +297,7 @@ class ArgoService implements ArgoServiceInterface {
         'uuid' => $entity->uuid(),
         'path' => $entity->toUrl()->toString(),
         'langcode' => $entity->language()->getId(),
-        'changed' => $changedTime,
+        'changed' => $changedTime
       ];
     }
 
@@ -360,14 +360,17 @@ class ArgoService implements ArgoServiceInterface {
   }
 
   /**
-   * Get entity UUID.
+   * Get entity UUID & revision ID.
    */
-  public function entityUuid($type, $id) {
+  public function entityInfo($type, $id) {
     $entity = $this->entityTypeManager
       ->getStorage($type)
       ->load($id);
 
-    return $entity->uuid();
+    return [
+      'uuid' => $entity->uuid(),
+      'revisionId' => $this->contentEntityExport->getRevisionId($entity)
+    ];
   }
 
 }

--- a/src/ArgoService.php
+++ b/src/ArgoService.php
@@ -102,7 +102,7 @@ class ArgoService implements ArgoServiceInterface {
    *   Entity type ID.
    * @param string $uuid
    *   Entity UUID.
-   * @param int $revision_id
+   * @param int $revisionId
    *   (optional) Entity revision ID.
    *
    * @return array
@@ -112,8 +112,8 @@ class ArgoService implements ArgoServiceInterface {
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
-  public function export(string $entityType, string $uuid, int $revision_id = NULL) {
-    $entity = $this->loadEntity($entityType, $uuid, $revision_id);
+  public function export(string $entityType, string $uuid, int $revisionId = NULL) {
+    $entity = $this->loadEntity($entityType, $uuid, $revisionId);
     return $this->contentEntityExport->export($entity);
   }
 
@@ -135,8 +135,8 @@ class ArgoService implements ArgoServiceInterface {
    * @throws \Drupal\typed_data\Exception\InvalidArgumentException
    */
   public function translate(string $entityType, string $uuid, array $translation) {
-    $revision_id = $translation['revisionId'] ?? NULL;
-    $entity = $this->loadEntity($entityType, $uuid, $revision_id);
+    $revisionId = $translation['revisionId'] ?? NULL;
+    $entity = $this->loadEntity($entityType, $uuid, $revisionId);
     $translated = $this->contentEntityTranslate->translate($entity, $translation);
 
     // Paragraphs are never displayed on their own, and so we should not apply
@@ -180,9 +180,9 @@ class ArgoService implements ArgoServiceInterface {
    * @param string $entityType
    *   Entity type ID.
    * @param string $uuid
-   *   Entity UUID.
-   *
-   * @param int|null $revision_id
+   *   Entity UUID
+   * @param int|null $revisionId
+   *   (optional) Entity revision ID.
    *
    * @return \Drupal\Core\Entity\ContentEntityInterface
    *   The loaded entity.
@@ -190,17 +190,17 @@ class ArgoService implements ArgoServiceInterface {
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    * @throws \Drupal\Core\TypedData\Exception\MissingDataException
    */
-  private function loadEntity(string $entityType, string $uuid, int $revision_id = NULL) {
+  private function loadEntity(string $entityType, string $uuid, int $revisionId = NULL) {
     // Unfortunately loading an entity by its uuid will only load the latest
     // "published" revision which could be different from the original entity.
     // Until Drupal core supports loading entity revisions by a uuid, we try and
     // load the entity by its revision id.
     // @see https://www.drupal.org/project/drupal/issues/1812202
-    if (isset($revision_id)) {
+    if (isset($revisionId)) {
       /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
       $entity = $this->entityTypeManager
         ->getStorage($entityType)
-        ->loadRevision($revision_id);
+        ->loadRevision($revisionId);
     } else {
       // If the revision id is not available, we resort to the uuid. Some
       // entities might not support revisions.

--- a/src/ArgoServiceInterface.php
+++ b/src/ArgoServiceInterface.php
@@ -14,13 +14,13 @@ interface ArgoServiceInterface {
    *   Entity type ID.
    * @param string $uuid
    *   Entity UUID.
-   * @param int $revision_id
+   * @param int $revisionId
    *   Entity revision ID.
    *
    * @return mixed
    *   Export object.
    */
-  public function export(string $entityType, string $uuid, int $revision_id);
+  public function export(string $entityType, string $uuid, int $revisionId);
 
   /**
    * Translate.

--- a/src/ArgoServiceInterface.php
+++ b/src/ArgoServiceInterface.php
@@ -20,7 +20,7 @@ interface ArgoServiceInterface {
    * @return mixed
    *   Export object.
    */
-  public function export(string $entityType, string $uuid, int $revisionId);
+  public function export(string $entityType, string $uuid, int $revisionId = NULL);
 
   /**
    * Translate.
@@ -50,8 +50,8 @@ interface ArgoServiceInterface {
   public function resetDeletionLog(array $deleted);
 
   /**
-   * Get entity UUID.
+   * Get entity UUID & revision ID.
    */
-  public function entityUuid($type, $id);
+  public function entityInfo($type, $id);
 
 }

--- a/src/ArgoServiceInterface.php
+++ b/src/ArgoServiceInterface.php
@@ -14,11 +14,13 @@ interface ArgoServiceInterface {
    *   Entity type ID.
    * @param string $uuid
    *   Entity UUID.
+   * @param int $revision_id
+   *   Entity revision ID.
    *
    * @return mixed
    *   Export object.
    */
-  public function export(string $entityType, string $uuid);
+  public function export(string $entityType, string $uuid, int $revision_id);
 
   /**
    * Translate.

--- a/src/ContentEntityExport.php
+++ b/src/ContentEntityExport.php
@@ -3,6 +3,8 @@
 namespace Drupal\argo;
 
 use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\RevisionableInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
 
 /**
@@ -184,14 +186,16 @@ class ContentEntityExport {
       $referencedEntityTypeId = $referencedEntity->getEntityTypeId();
       if (isset($traversableEntityTypes[$referencedEntityTypeId]) ||
         ($referencedEntityTypeId === 'node' && isset($traversableContentTypes[$referencedEntity->bundle()]))) {
+
         $references[] = [
           'entityType' => $referencedEntityTypeId,
           'uuid' => $referencedEntity->uuid(),
-          'revisionId' => $referencedEntity->getRevisionId(),
+          'revisionId' => $this->getRevisionId($referencedEntity),
         ];
       }
     }
     $translationOut['references'] = $references;
+    $translationOut['revisionId'] = $this->getRevisionId($entity);
 
     $translationOut['items'] = $this->flattenExport($translationOut['fields']);
     unset($translationOut['fields']);
@@ -262,4 +266,15 @@ class ContentEntityExport {
     return $flat;
   }
 
+  /**
+   * @return mixed|null
+   *   Revision ID if entity has one, else NULL.
+   */
+  public function getRevisionId(EntityInterface $entity) {
+    $revisionId = NULL;
+    if ($entity instanceof RevisionableInterface) {
+      $revisionId = $entity->getRevisionId();
+    }
+    return $revisionId;
+  }
 }

--- a/src/ContentEntityExport.php
+++ b/src/ContentEntityExport.php
@@ -187,6 +187,7 @@ class ContentEntityExport {
         $references[] = [
           'entityType' => $referencedEntityTypeId,
           'uuid' => $referencedEntity->uuid(),
+          'revisionId' => $referencedEntity->getRevisionId(),
         ];
       }
     }

--- a/src/ContentEntityTranslate.php
+++ b/src/ContentEntityTranslate.php
@@ -53,7 +53,8 @@ class ContentEntityTranslate {
     }
 
     // Copy src fields to target.
-    $srcEntity->addTranslation($targetLangcode, $srcEntity->getFields());
+    $array = $srcEntity->toArray();
+    $srcEntity->addTranslation($targetLangcode, $array);
 
     $targetEntity = $srcEntity->getTranslation($targetLangcode);
 

--- a/src/Controller/ArgoController.php
+++ b/src/Controller/ArgoController.php
@@ -76,8 +76,9 @@ class ArgoController extends ControllerBase {
   public function exportContentEntity(Request $request) {
     $entityType = $request->get('type');
     $uuid = $request->get('uuid');
+    $revision_id = $request->get('revision_id');
 
-    $export = $this->argoService->export($entityType, $uuid);
+    $export = $this->argoService->export($entityType, $uuid, $revision_id);
 
     return new JsonResponse($export);
   }

--- a/src/Controller/ArgoController.php
+++ b/src/Controller/ArgoController.php
@@ -76,9 +76,9 @@ class ArgoController extends ControllerBase {
   public function exportContentEntity(Request $request) {
     $entityType = $request->get('type');
     $uuid = $request->get('uuid');
-    $revision_id = $request->get('revision_id');
+    $revisionId = $request->get('revisionId');
 
-    $export = $this->argoService->export($entityType, $uuid, $revision_id);
+    $export = $this->argoService->export($entityType, $uuid, $revisionId);
 
     return new JsonResponse($export);
   }

--- a/src/Controller/ArgoController.php
+++ b/src/Controller/ArgoController.php
@@ -76,6 +76,24 @@ class ArgoController extends ControllerBase {
   public function exportContentEntity(Request $request) {
     $entityType = $request->get('type');
     $uuid = $request->get('uuid');
+
+    $export = $this->argoService->export($entityType, $uuid);
+
+    return new JsonResponse($export);
+  }
+
+  /**
+   * Exports a content entity revision for translation.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The request.
+   *
+   * @return \Symfony\Component\HttpFoundation\JsonResponse
+   *   The response object.
+   */
+  public function exportContentEntityRevision(Request $request) {
+    $entityType = $request->get('type');
+    $uuid = $request->get('uuid');
     $revisionId = $request->get('revisionId');
 
     $export = $this->argoService->export($entityType, $uuid, $revisionId);
@@ -173,9 +191,9 @@ class ArgoController extends ControllerBase {
     $type = $request->get('type');
     $id = $request->get('id');
 
-    $uuid = $this->argoService->entityUuid($type, $id);
+    $entityInfo = $this->argoService->entityInfo($type, $id);
 
-    return new JsonResponse(['uuid' => $uuid]);
+    return new JsonResponse($entityInfo);
   }
 
 }


### PR DESCRIPTION
## Notes
- Includes `revisionId` during export so we translate the correct revision of the entity. Argo relied on the uuid to load each entity for translation. This is problematic because it will only load the latest PUBLISHED revision for this entity. See https://www.drupal.org/project/drupal/issues/1812202 on drupal.org for adding support for revision uuid's.
- Uses `revisionId` during translation so the translations are attached to the correct entity revision.
- Changes the `changed` timestamp of the page/entity to ensure we don't save new(er) revisions that have timestamps in the past.
- Updates the `author` of the page/entity to reflect the Argo service account.

Notion doc: https://www.notion.so/tableaumkt/Argo-translation-issues-17178efc0be84668b2a5b91a7be2ea12