### PR TITLE
Exclude fields from Argo translations

### DIFF
--- a/argo.module
+++ b/argo.module
@@ -19,7 +19,8 @@ use Psr\Log\LogLevel;
  * Since deleted tracked entities won't show up in that query, we need to
  * log these deletions and clean up after they're accounted for.
  * Without this deletion log, we would have to check all entities and subtract
- * the ones not present after the last sync. The deletion log is a more efficient alternative.
+ * the ones not present after the last sync. The deletion log is a more efficient
+ * alternative.
  *
  * @param Drupal\Core\Entity\EntityInterface $entity
  *   Entity about to be deleted.
@@ -33,7 +34,9 @@ function argo_entity_delete(EntityInterface $entity) {
           'entityType' => $entity->getEntityTypeId(),
           'bundle' => $entity->bundle(),
           'uuid' => $entity->uuid(),
-        ])->execute();
+        ])
+        ->key('uuid')
+        ->execute();
     }
     catch (Exception $e) {
       \Drupal::logger('argo')->log(LogLevel::ERROR, $e->__toString());

--- a/argo.module
+++ b/argo.module
@@ -8,6 +8,8 @@
 use Drupal\Core\Database\Database;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\field\FieldConfigInterface;
 use Psr\Log\LogLevel;
 
 /**
@@ -37,4 +39,46 @@ function argo_entity_delete(EntityInterface $entity) {
       \Drupal::logger('argo')->log(LogLevel::ERROR, $e->__toString());
     }
   }
+}
+
+/**
+ * Implements hook_FORM_ID_alter().
+ *
+ * Exposes new field configuration to exclude field from being exported and
+ * translated by Argo. Its value can still be translated manually - changed
+ * per language. This is useful for certain string values such as display
+ * settings where the value itself should not be translated as it is used to
+ * control how content is rendered (e.g. css classes, event date/time timezone
+ * settings etc...).
+ */
+function argo_form_field_config_edit_form_alter(&$form, FormStateInterface $form_state) {
+  /** @var \Drupal\field\Entity\FieldConfig $field_config */
+  $field_config = $form_state->getFormObject()->getEntity();
+  $bundle_is_translatable = \Drupal::service('content_translation.manager')
+    ->isEnabled($field_config->getTargetEntityTypeId(), $field_config->getTargetBundle());
+
+  $form['argo_excluded'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Exclude from Argo translations'),
+    '#weight' => 0,
+    '#default_value' => $field_config->getThirdPartySetting('argo', 'excluded', 0),
+    '#description' => t('This field will no longer be exported and translated by Argo, but can still be translated manually.'),
+    '#states' => [
+      'visible' => [
+        ':input[name="translatable"]' => ['checked' => TRUE],
+      ],
+    ],
+    '#access' => $bundle_is_translatable,
+  );
+
+  $form['#entity_builders'][] = 'argo_entity_builder';
+}
+
+
+/**
+ * Entity builder callback.
+ */
+function argo_entity_builder($entity_type, FieldConfigInterface $entity, &$form, FormStateInterface $form_state) {
+  $exclude_from_translation = $form_state->getValue('argo_excluded');
+  $entity->setThirdPartySetting('argo', 'excluded', $exclude_from_translation);
 }

--- a/config/schema/argo.schema.yml
+++ b/config/schema/argo.schema.yml
@@ -1,0 +1,7 @@
+field.field.*.*.*.third_party.argo:
+  type: mapping
+  label: 'Argo translation field settings'
+  mapping:
+    excluded:
+      type: boolean
+      label: Excluded

--- a/src/ContentEntityExport.php
+++ b/src/ContentEntityExport.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\argo;
 
+use Drupal\Core\Config\Entity\ThirdPartySettingsInterface;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\RevisionableInterface;
@@ -35,6 +36,14 @@ class ContentEntityExport {
       if ($fieldItemDef instanceof FieldDefinitionInterface) {
         if ($fieldItemDef->getType() === 'language') {
           unset($translatableFields[$name]);
+        }
+
+        // User marked the field to be excluded.
+        if ($fieldItemDef instanceof ThirdPartySettingsInterface) {
+          $is_excluded = $fieldItemDef->getThirdPartySetting('argo', 'excluded', FALSE);
+          if ($is_excluded) {
+            unset($translatableFields[$name]);
+          }
         }
       }
     }


### PR DESCRIPTION
## QA
https://ad-hoc-perm-tableau-www.pantheonsite.io/

- Check node export for homepage: https://ad-hoc-perm-tableau-www.pantheonsite.io/argo/content-entity/node/0749c07f-11c7-4082-9887-f4edf1988129/export

compare with production: https://www.tableau.com/argo/content-entity/node/0749c07f-11c7-4082-9887-f4edf1988129/export

- [ ] Assert internal fields such as `seo_optimization` are exluded from the export.

## Release Notes
- New field configuration to exclude values from Argo export.