### PR TITLE
[Argo] Add support for config/locale translations

### DIFF
--- a/argo.links.menu.yml
+++ b/argo.links.menu.yml
@@ -1,0 +1,5 @@
+argo.settings:
+  title: 'Argo settings'
+  route_name: argo.settings
+  description: 'Configure Argo.'
+  parent: system.admin_config_regional

--- a/argo.routing.yml
+++ b/argo.routing.yml
@@ -1,4 +1,52 @@
-argo.updated:
+# Admin UI
+argo.settings:
+  path: '/admin/config/development/configuration/argo'
+  defaults:
+    _form: '\Drupal\argo\Form\SettingsForm'
+    _title: 'Argo'
+  requirements:
+    _permission: 'translate content using argo'
+
+# API Endpoints
+# Config translation
+argo.config.export:
+  path: /argo/config/{langcode}/export
+  defaults:
+    _title: 'Export config (entities) for translation'
+    _controller: '\Drupal\argo\Controller\ArgoController::exportConfig'
+  requirements:
+    _format: 'json'
+    _permission: 'translate content using argo'
+  methods: ['GET']
+  options:
+    no_cache: TRUE
+
+argo.config.translation:
+  path: /argo/config/{langcode}/translation
+  defaults:
+    _title: 'ARGO config translation endpoint'
+    _controller: '\Drupal\argo\Controller\ArgoController::translateConfig'
+  requirements:
+    _format: 'json'
+    _permission: 'translate content using argo'
+  methods: ['POST']
+  options:
+    no_cache: TRUE
+
+# Content translation
+argo.content.entity_uuid:
+  path: /argo/entity-uuid
+  defaults:
+    _title: 'Lookup UUID for an entity by ID'
+    _controller: '\Drupal\argo\Controller\ArgoController::entityUuid'
+  requirements:
+    _format: 'json'
+    _permission: 'translate content using argo'
+  methods: ['GET']
+  options:
+    no_cache: TRUE
+
+argo.content.updated:
   path: /argo/content-entity/{type}/updated
   defaults:
     _title: 'Get content entity metadata'
@@ -10,7 +58,7 @@ argo.updated:
   options:
     no_cache: TRUE
 
-argo.get_deletion_log:
+argo.content.get_deletion_log:
   path: /argo/content-entity/deletion-log
   defaults:
     _title: 'Fetch deleted entity IDs'
@@ -21,7 +69,7 @@ argo.get_deletion_log:
   options:
     no_cache: TRUE
 
-argo.reset_deletion_log:
+argo.content.reset_deletion_log:
   path: /argo/content-entity/deletion-log
   defaults:
     _title: 'Reset deleted entity ID log'
@@ -32,7 +80,7 @@ argo.reset_deletion_log:
   options:
     no_cache: TRUE
 
-argo.export:
+argo.content.export:
   path: /argo/content-entity/{type}/{uuid}/export
   defaults:
     _title: 'Export content entity for translation'
@@ -56,7 +104,7 @@ argo.export_revision:
   options:
     no_cache: TRUE
 
-argo.translation:
+argo.content.translation:
   path: /argo/content-entity/{type}/{uuid}/translation
   defaults:
     _title: 'ARGO translation endpoint'
@@ -77,5 +125,30 @@ argo.entity_uuid:
     _format: 'json'
     _permission: 'translate content using argo'
   methods: ['GET']
+  options:
+    no_cache: TRUE
+
+# UI String (locale) translation
+argo.locale.export:
+  path: /argo/locale/{langcode}/export
+  defaults:
+    _title: 'Export UI strings for translation'
+    _controller: '\Drupal\argo\Controller\ArgoController::exportLocale'
+  requirements:
+    _format: 'json'
+    _permission: 'translate content using argo'
+  methods: ['GET']
+  options:
+    no_cache: TRUE
+
+argo.locale.translation:
+  path: /argo/locale/{langcode}/translation
+  defaults:
+    _title: 'ARGO UI string translation endpoint'
+    _controller: '\Drupal\argo\Controller\ArgoController::translateLocale'
+  requirements:
+    _format: 'json'
+    _permission: 'translate content using argo'
+  methods: ['POST']
   options:
     no_cache: TRUE

--- a/argo.routing.yml
+++ b/argo.routing.yml
@@ -34,18 +34,6 @@ argo.config.translation:
     no_cache: TRUE
 
 # Content translation
-argo.content.entity_uuid:
-  path: /argo/entity-uuid
-  defaults:
-    _title: 'Lookup UUID for an entity by ID'
-    _controller: '\Drupal\argo\Controller\ArgoController::entityUuid'
-  requirements:
-    _format: 'json'
-    _permission: 'translate content using argo'
-  methods: ['GET']
-  options:
-    no_cache: TRUE
-
 argo.content.updated:
   path: /argo/content-entity/{type}/updated
   defaults:
@@ -113,18 +101,6 @@ argo.content.translation:
     _format: 'json'
     _permission: 'translate content using argo'
   methods: ['POST']
-  options:
-    no_cache: TRUE
-
-argo.entity_uuid:
-  path: /argo/entity-uuid
-  defaults:
-    _title: 'Lookup UUID for an entity by ID'
-    _controller: '\Drupal\argo\Controller\ArgoController::entityUuid'
-  requirements:
-    _format: 'json'
-    _permission: 'translate content using argo'
-  methods: ['GET']
   options:
     no_cache: TRUE
 

--- a/argo.routing.yml
+++ b/argo.routing.yml
@@ -104,6 +104,18 @@ argo.content.translation:
   options:
     no_cache: TRUE
 
+argo.content.entity_uuid:
+  path: /argo/entity-uuid
+  defaults:
+    _title: 'Lookup UUID for an entity by ID'
+    _controller: '\Drupal\argo\Controller\ArgoController::entityUuid'
+  requirements:
+    _format: 'json'
+    _permission: 'translate content using argo'
+  methods: ['GET']
+  options:
+    no_cache: TRUE
+
 # UI String (locale) translation
 argo.locale.export:
   path: /argo/locale/{langcode}/export

--- a/argo.services.yml
+++ b/argo.services.yml
@@ -1,4 +1,8 @@
 services:
+  # Channel specific logger derived from the base service.
+  logger.channel.argo:
+    parent: logger.channel_base
+    arguments: ['argo']
   argo.service:
     class: Drupal\argo\ArgoService
     arguments:

--- a/argo.services.yml
+++ b/argo.services.yml
@@ -1,15 +1,31 @@
 services:
   argo.service:
     class: Drupal\argo\ArgoService
-    arguments: ['@entity.repository',
-                '@entity_type.manager',
-                '@entity_field.manager',
-                '@argo.export',
-                '@argo.translate',
-                '@content_moderation.moderation_information',
-                '@database']
-  argo.export:
+    arguments:
+      - '@argo.config_service'
+      - '@argo.content_export'
+      - '@argo.content_translate'
+      - '@argo.locale_service'
+      - '@entity.repository'
+      - '@entity_type.manager'
+      - '@entity_field.manager'
+      - '@content_moderation.moderation_information'
+      - '@database'
+  argo.config_service:
+    class: Drupal\argo\ConfigService
+    arguments:
+      - '@config.factory'
+      - '@config.storage'
+      - '@config.manager'
+      - '@config.typed'
+      - '@language_manager'
+  argo.content_export:
     class: Drupal\argo\ContentEntityExport
-  argo.translate:
+  argo.content_translate:
     class: Drupal\argo\ContentEntityTranslate
-    arguments: ['@typed_data.data_fetcher']
+    arguments:
+      - '@typed_data.data_fetcher'
+  argo.locale_service:
+    class: Drupal\argo\LocaleService
+    arguments:
+      - '@locale.storage'

--- a/config/schema/argo.schema.yml
+++ b/config/schema/argo.schema.yml
@@ -1,3 +1,17 @@
+argo.settings:
+  type: config_object
+  label: 'Argo Settings'
+  mapping:
+    config:
+      type: mapping
+      label: 'Configuration translation settings'
+      mapping:
+        translatable:
+          type: sequence
+          label: 'List of configurations to include for Argo translation'
+          sequence:
+            type: string
+
 field.field.*.*.*.third_party.argo:
   type: mapping
   label: 'Argo translation field settings'

--- a/src/ArgoService.php
+++ b/src/ArgoService.php
@@ -131,8 +131,6 @@ class ArgoService implements ArgoServiceInterface {
     $this->connection = $connection;
   }
 
-
-
   /**
    * {@inheritdoc}
    */

--- a/src/ArgoService.php
+++ b/src/ArgoService.php
@@ -16,7 +16,6 @@ use Drupal\Core\Entity\RevisionLogInterface;
 use Drupal\Core\Entity\Sql\TableMappingInterface;
 use Drupal\Core\Field\EntityReferenceFieldItemListInterface;
 use Drupal\Core\Language\Language;
-use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\paragraphs\ParagraphInterface;
 use Drupal\user\EntityOwnerInterface;
 
@@ -24,6 +23,34 @@ use Drupal\user\EntityOwnerInterface;
  * Interacts with Argo.
  */
 class ArgoService implements ArgoServiceInterface {
+
+  /**
+   * Configuration (entity) string export/import service.
+   *
+   * @var \Drupal\argo\ConfigService
+   */
+  private $configService;
+
+  /**
+   * Content exporter.
+   *
+   * @var ContentEntityExport
+   */
+  private $contentEntityExport;
+
+  /**
+   * Content translation service.
+   *
+   * @var ContentEntityTranslate
+   */
+  private $contentEntityTranslate;
+
+  /**
+   * UI string translation service.
+   *
+   * @var \Drupal\argo\LocaleService
+   */
+  private $localeService;
 
   /**
    * The core entity repository service.
@@ -47,20 +74,6 @@ class ArgoService implements ArgoServiceInterface {
   private $entityFieldManager;
 
   /**
-   * Exporter.
-   *
-   * @var ContentEntityExport
-   */
-  private $contentEntityExport;
-
-  /**
-   * Translate.
-   *
-   * @var ContentEntityTranslate
-   */
-  private $contentEntityTranslate;
-
-  /**
    * Moderation info.
    *
    * @var \Drupal\content_moderation\ModerationInformationInterface
@@ -77,80 +90,75 @@ class ArgoService implements ArgoServiceInterface {
   /**
    * The service constructor.
    *
+   * @param ConfigService $configService
+   *   Config exporter/importer service.
+   * @param ContentEntityExport $contentEntityExport
+   *   Exporter.
+   * @param ContentEntityTranslate $contentEntityTranslate
+   *   Content entity translation service.
+   * @param \Drupal\argo\LocaleService $localeService
+   *   UI string translation service.
    * @param \Drupal\Core\Entity\EntityRepositoryInterface $entityRepository
    *   The core entity repository service.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
    *   The core entity type manager service.
    * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entityFieldManager
    *   The core entity field manager service.
-   * @param ContentEntityExport $contentEntityExport
-   *   Exporter.
-   * @param ContentEntityTranslate $contentEntityTranslate
-   *   Content entity translation service.
    * @param \Drupal\content_moderation\ModerationInformationInterface $moderationInfo
    *   Moderation info.
    * @param \Drupal\Core\Database\Connection $connection
    *   DB connection.
    */
   public function __construct(
+    ConfigService $configService,
+    ContentEntityExport $contentEntityExport,
+    ContentEntityTranslate $contentEntityTranslate,
+    LocaleService $localeService,
     EntityRepositoryInterface $entityRepository,
     EntityTypeManagerInterface $entityTypeManager,
     EntityFieldManagerInterface $entityFieldManager,
-    ContentEntityExport $contentEntityExport,
-    ContentEntityTranslate $contentEntityTranslate,
     ModerationInformationInterface $moderationInfo,
     Connection $connection
   ) {
     $this->entityRepository = $entityRepository;
-    $this->entityTypeManager = $entityTypeManager;
-    $this->entityFieldManager = $entityFieldManager;
+    $this->configService = $configService;
     $this->contentEntityExport = $contentEntityExport;
     $this->contentEntityTranslate = $contentEntityTranslate;
+    $this->localeService = $localeService;
+    $this->entityTypeManager = $entityTypeManager;
+    $this->entityFieldManager = $entityFieldManager;
     $this->moderationInfo = $moderationInfo;
     $this->connection = $connection;
   }
 
+
+
   /**
-   * Export.
-   *
-   * @param string $entityType
-   *   Entity type ID.
-   * @param string $uuid
-   *   Entity UUID.
-   * @param array $traversableEntityTypes
-   *   Traversable entity types.
-   * @param array $traversableContentTypes
-   *   Traversable content types.
-   * @param int|null $revisionId
-   *   (optional) Entity revision ID.
-   *
-   * @return array
-   *   Export.
-   *
-   * @throws \Drupal\Core\TypedData\Exception\MissingDataException
-   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
-   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   * {@inheritdoc}
    */
-  public function export(string $entityType, string $uuid, array $traversableEntityTypes, array $traversableContentTypes, int $revisionId = NULL) {
+  public function exportConfig(string $langcode, array $options = []) {
+    return $this->configService->export($langcode, $options);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function translateConfig(string $langcode, array $translations) {
+    $this->configService->import($langcode, $translations);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function exportContent(string $entityType, string $uuid, array $traversableEntityTypes, array $traversableContentTypes, int $revisionId = NULL) {
     $entity = $this->loadEntity($entityType, $uuid, $revisionId);
     return $this->contentEntityExport->export($entity, $traversableEntityTypes, $traversableContentTypes);
   }
 
   /**
-   * Translate.
-   *
-   * @param string $entityType
-   *   Entity type.
-   * @param string $uuid
-   *   UUID.
-   * @param array $translations
-   *   Translations.
-   *
-   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
-   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
-   * @throws \Drupal\Core\Entity\EntityStorageException
+   * {@inheritdoc}
    */
-  public function translate(string $entityType, string $uuid, array $translations) {
+  public function translateContent(string $entityType, string $uuid, array $translations) {
     $rootTranslation = $translations['root'];
     $childTranslations = $translations['children'];
 
@@ -580,6 +588,20 @@ class ArgoService implements ArgoServiceInterface {
       'uuid' => $entity->uuid(),
       'revisionId' => $this->contentEntityExport->getRevisionId($entity)
     ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function exportLocale(string $langcode, array $options = []) {
+    return $this->localeService->export($langcode, $options);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function translateLocale(string $langcode, array $translations) {
+    $this->localeService->import($langcode, $translations);
   }
 
 }

--- a/src/ArgoServiceInterface.php
+++ b/src/ArgoServiceInterface.php
@@ -17,9 +17,9 @@ interface ArgoServiceInterface {
    *   [
    *     'include_translations' => 'Whether or not to include already translated
    *       values',
-   *   ]
+   *   ].
    *
-   *  @return mixed
+   * @return mixed
    *   List of configuration strings as JSON. Each item consists of:
    *    [
    *     'config_id' => 'The unique identifier for the configuration',
@@ -47,7 +47,7 @@ interface ArgoServiceInterface {
    *     'translation' => 'The translated value of the string.',
    *     'context' => 'Context for the string.',
    *     'url' => 'The url at which the string is found.',
-   *   ]
+   *   ].
    */
   public function translateConfig(string $langcode, array $translations);
 
@@ -117,7 +117,7 @@ interface ArgoServiceInterface {
    *   [
    *     'include_translations' => 'Whether or not to include already translated
    *       values',
-   *   ]
+   *   ].
    *
    * @return mixed
    *   List of UI strings as JSON object. Each item consists of:
@@ -143,7 +143,7 @@ interface ArgoServiceInterface {
    *     'translation' => 'The translated value of the string.',
    *     'context' => 'Context for the string.',
    *     'url' => 'The url at which the string is found.',
-   *   ]
+   *   ].
    */
   public function translateLocale(string $langcode, array $translations);
 

--- a/src/ArgoServiceInterface.php
+++ b/src/ArgoServiceInterface.php
@@ -8,7 +8,27 @@ namespace Drupal\argo;
 interface ArgoServiceInterface {
 
   /**
-   * Export.
+   * Export configuration (entity) strings.
+   *
+   * @param string $langcode
+   *   Language to retrieve (untranslated) config values for.
+   * @param array $options
+   *   List of options used to control export.
+   */
+  public function exportConfig(string $langcode, array $options = []);
+
+  /**
+   * Import configuration (entity) translations.
+   *
+   * @param string $langcode
+   *   The language to save the config translations in.
+   * @param array $translations
+   *   List of config translations.
+   */
+  public function translateConfig(string $langcode, array $translations);
+
+  /**
+   * Export content entity.
    *
    * @param string $entityType
    *   Entity type ID.
@@ -24,19 +44,19 @@ interface ArgoServiceInterface {
    * @return mixed
    *   Export object.
    */
-  public function export(string $entityType, string $uuid, array $traversableEntityTypes, array $traversableContentTypes, int $revisionId = NULL);
+  public function exportContent(string $entityType, string $uuid, array $traversableEntityTypes, array $traversableContentTypes, int $revisionId = NULL);
 
   /**
-   * Translate.
+   * Translate content entity.
    *
    * @param string $entityType
    *   Entity type ID.
    * @param string $uuid
    *   Entity UUID.
-   * @param array $translation
+   * @param array $translations
    *   Translation object.
    */
-  public function translate(string $entityType, string $uuid, array $translation);
+  public function translateContent(string $entityType, string $uuid, array $translations);
 
   /**
    * Get updated.
@@ -62,5 +82,25 @@ interface ArgoServiceInterface {
    * Get entity UUID & revision ID.
    */
   public function entityInfo($type, $id);
+
+  /**
+   * Export UI strings.
+   *
+   * @param string $langcode
+   *   Language to retrieve (untranslated) config values for.
+   * @param array $options
+   *   List of options used to control export.
+   */
+  public function exportLocale(string $langcode, array $options = []);
+
+  /**
+   * Import UI translations.
+   *
+   * @param string $langcode
+   *   The language to save the config translations in.
+   * @param array $translations
+   *   List of config translations.
+   */
+  public function translateLocale(string $langcode, array $translations);
 
 }

--- a/src/ArgoServiceInterface.php
+++ b/src/ArgoServiceInterface.php
@@ -14,6 +14,22 @@ interface ArgoServiceInterface {
    *   Language to retrieve (untranslated) config values for.
    * @param array $options
    *   List of options used to control export.
+   *   [
+   *     'include_translations' => 'Whether or not to include already translated
+   *       values',
+   *   ]
+   *
+   *  @return mixed
+   *   List of configuration strings as JSON. Each item consists of:
+   *    [
+   *     'config_id' => 'The unique identifier for the configuration',
+   *     'key' => 'The config key of the string (e.g. settings.group.name)',
+   *     'string' => 'The original string value in the source language',
+   *     'translation' => 'A copy of the original string to be replaced by the
+   *       translator',
+   *     'context' => 'Context for the string.',
+   *     'url' => 'The url at which the string is found.',
+   *   ]
    */
   public function exportConfig(string $langcode, array $options = []);
 
@@ -23,7 +39,15 @@ interface ArgoServiceInterface {
    * @param string $langcode
    *   The language to save the config translations in.
    * @param array $translations
-   *   List of config translations.
+   *   List of config string translations. Each item contains:
+   *   [
+   *     'config_id' => 'The unique identifier for the configuration',
+   *     'key' => 'The config key of the string (e.g. settings.group.name)',
+   *     'string' => 'The original string value in the source language',
+   *     'translation' => 'The translated value of the string.',
+   *     'context' => 'Context for the string.',
+   *     'url' => 'The url at which the string is found.',
+   *   ]
    */
   public function translateConfig(string $langcode, array $translations);
 
@@ -87,9 +111,23 @@ interface ArgoServiceInterface {
    * Export UI strings.
    *
    * @param string $langcode
-   *   Language to retrieve (untranslated) config values for.
+   *   Language to retrieve (untranslated) UI string values for.
    * @param array $options
    *   List of options used to control export.
+   *   [
+   *     'include_translations' => 'Whether or not to include already translated
+   *       values',
+   *   ]
+   *
+   * @return mixed
+   *   List of UI strings as JSON object. Each item consists of:
+   *    [
+   *     'string' => 'The original string value in the source language',
+   *     'translation' => 'A copy of the original string to be replaced by the
+   *       translator',
+   *     'context' => 'Context for the string.',
+   *     'url' => 'The url at which the string is found.',
+   *   ]
    */
   public function exportLocale(string $langcode, array $options = []);
 
@@ -97,9 +135,15 @@ interface ArgoServiceInterface {
    * Import UI translations.
    *
    * @param string $langcode
-   *   The language to save the config translations in.
+   *   The language to save the translations in.
    * @param array $translations
-   *   List of config translations.
+   *   A list of UI translations of the format:
+   *   [
+   *     'string' => 'The original string value in the source language',
+   *     'translation' => 'The translated value of the string.',
+   *     'context' => 'Context for the string.',
+   *     'url' => 'The url at which the string is found.',
+   *   ]
    */
   public function translateLocale(string $langcode, array $translations);
 

--- a/src/ConfigService.php
+++ b/src/ConfigService.php
@@ -1,0 +1,309 @@
+<?php
+
+namespace Drupal\argo;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ConfigManagerInterface;
+use Drupal\Core\Config\StorageInterface;
+use Drupal\Core\Config\TypedConfigManagerInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\TypedData\TraversableTypedDataInterface;
+use Drupal\Core\TypedData\TypedDataInterface;
+use Drupal\webform\Entity\Webform;
+use Drupal\webform\WebformTranslationConfigManager;
+use Drupal\webform\WebformTranslationManagerInterface;
+
+/**
+ * Handles config (entity) export and translation.
+ */
+class ConfigService {
+
+  /**
+   * Argo settings.
+   *
+   * @var \Drupal\Core\Config\ImmutableConfig
+   */
+  protected $config;
+
+  /**
+   * The storage instance for reading configuration data.
+   *
+   * @var \Drupal\Core\Config\StorageInterface
+   */
+  protected $configStorage;
+
+  /**
+   * The configuration factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * The language manager.
+   *
+   * @var \Drupal\language\ConfigurableLanguageManagerInterface
+   */
+  protected $languageManager;
+
+  /**
+   * The typed config manager.
+   *
+   * @var \Drupal\Core\Config\TypedConfigManagerInterface
+   */
+  protected $typedConfigManager;
+
+  /**
+   * The configuration manager.
+   *
+   * @var \Drupal\Core\Config\ConfigManagerInterface
+   */
+  protected $configManager;
+
+    /**
+     * Creates a new instance of the Argo configuration translation service.
+     *
+     * @param ConfigFactoryInterface $config_factory
+     *   The Drupal config factory.
+     * @param \Drupal\Core\Config\StorageInterface $config_storage
+     *   The storage object to use for reading configuration data.
+     * @param ConfigManagerInterface $config_manager
+     * @param \Drupal\Core\Config\TypedConfigManagerInterface $typed_config
+     *   The typed configuration manager.
+     * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
+     *   The language manager service.
+     */
+  public function __construct(
+    ConfigFactoryInterface $config_factory,
+    StorageInterface $config_storage,
+    ConfigManagerInterface $config_manager,
+    TypedConfigManagerInterface $typed_config,
+    LanguageManagerInterface $language_manager) {
+    $this->configFactory = $config_factory;
+    $this->configStorage = $config_storage;
+    $this->configManager = $config_manager;
+    $this->typedConfigManager = $typed_config;
+    $this->languageManager = $language_manager;
+
+    $this->config = $this->configFactory->get('argo.settings');
+  }
+
+  /**
+   * Export a list of config strings for translation.
+   *
+   * @param string $langcode
+   *   The langcode for which to export config strings.
+   * @param array $options
+   *   Options to control the export.
+   *   [
+   *     'include_translations' => 'Whether or not to include already translated
+   *       values',
+   *   ]
+   *
+   * @return array
+   *   List of configuration strings:
+   *    [
+   *     'config_id' => 'The unique identifier for the configuration',
+   *     'key' => 'The config key of the string (e.g. settings.group.name)',
+   *     'string' => 'The original string value in the source language',
+   *     'translation' => 'A copy of the original string to be replaced by the
+   *       translator',
+   *     'context' => 'Context for the string.',
+   *     'url' => 'The url at which the string is found.',
+   *   ]
+   */
+  public function export(string $langcode, array $options = []) {
+    // Merge in default options.
+    $options = ['include_translations' => TRUE] + $options;
+    $items = [];
+    // Retrieves a list of configs which are eligible for Argo export.
+    $translatable_config_keys = $this->config->get('config.translatable');
+    foreach ($translatable_config_keys as $key) {
+      $prefix = str_replace('*', '', $key);
+      $items = array_merge($items, $this->doExport($langcode, $this->configStorage->listAll($prefix), $options));
+    }
+
+    return $items;
+  }
+
+  /**
+   * Imports a set of config (entity) translations.
+   *
+   * @param string $langcode
+   *   The langcode to import the translations for.
+   * @param array $translations
+   *   A list of translations of the format:
+   *   [
+   *     'config_id' => 'The unique identifier for the configuration',
+   *     'key' => 'The config key of the string (e.g. settings.group.name)',
+   *     'string' => 'The original string value in the source language',
+   *     'translation' => 'The translated value of the string.',
+   *     'context' => 'Context for the string.',
+   *     'url' => 'The url at which the string is found.',
+   *   ]
+   */
+  public function import(string $langcode, array $translations) {
+    $configs = [];
+
+    foreach ($translations as $translation) {
+      $config_id = $translation['config_id'];
+      $key = $translation['key'];
+      $translation = $translation['translation'];
+      // Load the config translation and statically store in an array so we
+      // can save all of them at once at the very end.
+      if (!isset($configs[$config_id])) {
+        $configs[$config_id] = $this->languageManager->getLanguageConfigOverride($langcode, $config_id);
+      }
+      $config = $configs[$config_id];
+      $config->set($key, $translation);
+    }
+
+    // Bulk save all the changes.
+    foreach ($configs as $config) {
+      $config->save();
+    }
+  }
+
+  // Internal helper functions.
+
+  /**
+   * Gets list of translatable data for a given config name/id.
+   *
+   * @param string $name
+   *   Configuration object name.
+   *
+   * @return array
+   *   Array of translatable elements of the default configuration in $name.
+   */
+  protected function getTranslatableConfig(string $name) {
+    // Create typed configuration wrapper based on install storage data.
+    $data = $this->configStorage->read($name);
+    $typed_config = $this->typedConfigManager->createFromNameAndData($name, $data);
+    if ($typed_config instanceof TraversableTypedDataInterface) {
+      return $this->getTranslatableData($typed_config);
+    }
+    return [];
+  }
+
+  /**
+   * Gets translatable configuration data for a typed configuration element.
+   *
+   * @param \Drupal\Core\TypedData\TypedDataInterface $element
+   *   Typed configuration element.
+   *
+   * @return array|\Drupal\Core\StringTranslation\TranslatableMarkup
+   *   A nested array matching the exact structure under $element with only the
+   *   elements that are translatable wrapped into a TranslatableMarkup. If the
+   *   provided $element is not traversable, the return value is a single
+   *   TranslatableMarkup.
+   */
+  protected function getTranslatableData(TypedDataInterface $element) {
+    $translatable = [];
+    if ($element instanceof TraversableTypedDataInterface) {
+      foreach ($element as $key => $property) {
+        $value = $this->getTranslatableData($property);
+        if (!empty($value)) {
+          $translatable[$key] = $value;
+        }
+      }
+    }
+    else {
+      // Something is only translatable by Locale if there is a string in the
+      // first place.
+      $value = $element->getValue();
+      $definition = $element->getDataDefinition();
+      if (!empty($definition['translatable']) && $value !== '' && $value !== NULL) {
+        return $value;
+      }
+    }
+    return $translatable;
+  }
+
+  /**
+   * Do the export of config translations for a given list of config names.
+   *
+   * @param string $langcode
+   *   The langcode for which to export config strings.
+   * @param array $names
+   *   The list of config id's to export the translations for.
+   * @param array $options
+   *   Additional export options.
+   *
+   * @return array
+   *   List of config strings with metadata about the config, context etc...
+   *
+   * @see \Drupal\argo\ConfigTranslation::export for list of available options.]
+   */
+  protected function doExport(string $langcode, array $names, array $options) {
+    $export = [];
+    $include_translations = $options['include_translations'];
+    foreach ($names as $name) {
+      $config = $this->getTranslatableConfig($name);
+      if (empty($config)) {
+        // If there is nothing translatable in this configuration, skip it.
+        continue;
+      }
+
+      $config_translation = $this->languageManager->getLanguageConfigOverride($langcode, $name)->get();
+
+      // Webforms require special handling of their elements.
+      $is_webform = strpos($name, 'webform') === 0;
+
+      if ($is_webform) {
+          $webform = $this->configManager->loadConfigEntityByName($name);
+          /** @var WebformTranslationManagerInterface $webform_translation_manager */
+          $webform_translation_manager = \Drupal::service('webform.translation_manager');
+          $config['elements'] = $webform_translation_manager->getSourceElements($webform);
+          $config_translation['elements'] = $webform_translation_manager->getTranslationElements($webform, $langcode);
+      }
+
+      foreach ($config as $key => $value) {
+        $translation = $config_translation[$key] ?? [];
+        // Skip adding config values which already contain a translation if we
+        // are filtering out existing translations in the export.
+        if (!$include_translations && !empty($translation)) {
+          continue;
+        }
+        $result = $this->prepareForExport($value, $key);
+        foreach ($result as &$item) {
+            $item['config_id'] = $name;
+        }
+        $export = array_merge($export, $result);
+      }
+    }
+
+    return $export;
+  }
+
+  /**
+   * Prepares a config string value for export.
+   *
+   * @param $value
+   *   The source string value.
+   * @param $key
+   *   The key in the configuration at which the string is found.
+   *
+   * @return array
+   *   Array of config string data ready for export.
+   */
+  protected function prepareForExport($value, $key, &$export = []) {
+    if (is_array($value)) {
+      foreach ($value as $nested_key => $nested_value) {
+        $this->prepareForExport($nested_value, $key . '.' . $nested_key, $export);
+      }
+    }
+    else {
+      $export[] = [
+        'key' => $key,
+        'string' => $value,
+        'translation' => $value,
+        // @todo figure out a way to provide context to the translator.
+        'context' => '@todo',
+        // @todo figure out a way to provide a url to the string in context.
+        'url' => '@todo',
+      ];
+    }
+
+    return $export;
+  }
+}

--- a/src/ConfigService.php
+++ b/src/ConfigService.php
@@ -11,7 +11,6 @@ use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Serialization\Yaml;
 use Drupal\Core\TypedData\TraversableTypedDataInterface;
 use Drupal\Core\TypedData\TypedDataInterface;
-use Drupal\webform\WebformTranslationManagerInterface;
 
 /**
  * Handles config (entity) export and translation.
@@ -119,6 +118,8 @@ class ConfigService {
     // Retrieves a list of configs which are eligible for Argo export.
     $translatable_config_keys = $this->config->get('config.translatable');
     foreach ($translatable_config_keys as $key) {
+      // @todo Make this work with fuzzy sub keys. Currently this only works
+      // when the key has the asterisk at the end of the config name.
       $prefix = str_replace('*', '', $key);
       $items = array_merge($items, $this->doExport($langcode, $this->configStorage->listAll($prefix), $options));
     }
@@ -160,7 +161,7 @@ class ConfigService {
         if ($this->isWebformConfig($config_id)) {
           /** @var \Drupal\webform\WebformInterface $webform */
           $webform = $this->configManager->loadConfigEntityByName($config_id);
-          /** @var WebformTranslationManagerInterface $webform_translation_manager */
+          /** @var \Drupal\webform\WebformTranslationManagerInterface $webform_translation_manager */
           $webform_translation_manager = \Drupal::service('webform.translation_manager');
           $configs[$config_id]->set('elements', $webform_translation_manager->getTranslationElements($webform, $langcode));
         }
@@ -263,7 +264,7 @@ class ConfigService {
    * @return array
    *   List of config strings with metadata about the config, context etc...
    *
-   * @see \Drupal\argo\ConfigTranslation::export for list of available options.]
+   * @see \Drupal\argo\ConfigTranslation::export for list of available options.
    */
   protected function doExport(string $langcode, array $names, array $options) {
     $export = [];

--- a/src/ConfigService.php
+++ b/src/ConfigService.php
@@ -143,12 +143,14 @@ class ConfigService {
         }
 
         $items = $this->doExport($config);
-        foreach ($items as &$item) {
+        foreach ($items as $delta => &$item) {
+          $item['config_id'] = $config_name;
           $translation = NestedArray::getValue($config_translation, explode('.', $item['key']));
-          if (!$options['include_translations'] && !empty($translation)) {
+          $has_translation = !empty($translation) && $translation !== $item['string'];
+          if (!$options['include_translations'] && $has_translation) {
+            unset($items[$delta]);
             continue;
           }
-          $item['config_id'] = $config_name;
         }
         $export = array_merge($export, $items);
       }

--- a/src/ConfigService.php
+++ b/src/ConfigService.php
@@ -162,7 +162,7 @@ class ConfigService {
           $webform = $this->configManager->loadConfigEntityByName($config_id);
           /** @var WebformTranslationManagerInterface $webform_translation_manager */
           $webform_translation_manager = \Drupal::service('webform.translation_manager');
-          $config[$config_id]['elements'] = $webform_translation_manager->getTranslationElements($webform, $langcode);
+          $configs[$config_id]->set('elements', $webform_translation_manager->getTranslationElements($webform, $langcode));
         }
       }
       $config = $configs[$config_id];
@@ -173,7 +173,9 @@ class ConfigService {
     foreach ($configs as $config_id => $config) {
       // Convert webform elements back to YAML prior to saving.
       if ($this->isWebformConfig($config_id)) {
-        $config['elements'] = ($config['elements']) ? Yaml::encode($config['elements']) : '';
+        $elements = $config->get('elements', []);
+        $elements_yaml = ($elements) ? Yaml::encode($elements) : '';
+        $config->set('elements', $elements_yaml);
       }
 
       $config->save();

--- a/src/Controller/ArgoController.php
+++ b/src/Controller/ArgoController.php
@@ -52,7 +52,7 @@ class ArgoController extends ControllerBase {
    */
   public function exportConfig(Request $request) {
     $langcode = $request->get('langcode');
-    $include_translations = (bool) $request->query->get('include-translations', FALSE);
+    $include_translations = intval($request->query->get('include-translations', FALSE));
     $export = $this->argoService->exportConfig($langcode, [
       'include_translations' => $include_translations,
     ]);
@@ -265,7 +265,7 @@ class ArgoController extends ControllerBase {
    */
   public function exportLocale(Request $request) {
     $langcode = $request->get('langcode');
-    $include_translations = (bool) $request->query->get('include-translations', FALSE);
+    $include_translations = intval($request->query->get('include-translations', FALSE));
     $export = $this->argoService->exportLocale($langcode, [
       'include_translations' => $include_translations,
     ]);

--- a/src/Controller/ArgoController.php
+++ b/src/Controller/ArgoController.php
@@ -146,7 +146,7 @@ class ArgoController extends ControllerBase {
     $traversableEntityTypes = $request->get('entity-types');
     $traversableContentTypes = $request->get('content-types');
 
-    $export = $this->argoService->export($entityType, $uuid, $traversableEntityTypes, $traversableContentTypes);
+    $export = $this->argoService->exportContent($entityType, $uuid, $traversableEntityTypes, $traversableContentTypes);
 
     return new JsonResponse($export);
   }
@@ -167,7 +167,7 @@ class ArgoController extends ControllerBase {
     $traversableContentTypes = $request->get('content-types');
     $revisionId = $request->get('revisionId');
 
-    $export = $this->argoService->export($entityType, $uuid, $traversableEntityTypes, $traversableContentTypes, $revisionId);
+    $export = $this->argoService->exportContent($entityType, $uuid, $traversableEntityTypes, $traversableContentTypes, $revisionId);
 
     return new JsonResponse($export);
   }
@@ -190,7 +190,7 @@ class ArgoController extends ControllerBase {
     $translation = json_decode($request->getContent(), TRUE);
 
     try {
-      $this->argoService->translate($entityType, $uuid, $translation);
+      $this->argoService->translateContent($entityType, $uuid, $translation);
     }
     catch (\Exception $e) {
       $this->logger->log(LogLevel::ERROR, $e->__toString());

--- a/src/Controller/ArgoController.php
+++ b/src/Controller/ArgoController.php
@@ -42,6 +42,47 @@ class ArgoController extends ControllerBase {
   }
 
   /**
+   * Exports config strings for translation.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The request.
+   *
+   * @return \Symfony\Component\HttpFoundation\JsonResponse
+   *   The response object.
+   */
+  public function exportConfig(Request $request) {
+    $langcode = $request->get('langcode');
+    $export = $this->argoService->exportConfig($langcode);
+
+    return new JsonResponse($export);
+  }
+
+  /**
+   * Translates config strings into Drupal.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The request.
+   *
+   * @return \Symfony\Component\HttpFoundation\JsonResponse
+   *   The response object.
+   */
+  public function translateConfig(Request $request) {
+    $langcode = $request->get('langcode');
+    $translations = Json::decode($request->getContent());
+
+    try {
+      $this->argoService->translateConfig($langcode, $translations);
+    } catch (\Exception $e) {
+      \Drupal::logger('argo')->log(LogLevel::ERROR, $e->__toString());
+      return new JsonResponse([
+        'message' => $e->__toString(),
+      ],
+        Response::HTTP_INTERNAL_SERVER_ERROR);
+    }
+    return new JsonResponse();
+  }
+
+  /**
    * Lists updated editorial content entity metadata.
    *
    * Uses a single 'changed' field type.
@@ -208,6 +249,47 @@ class ArgoController extends ControllerBase {
     $entityInfo = $this->argoService->entityInfo($type, $id);
 
     return new JsonResponse($entityInfo);
+  }
+
+  /**
+   * Exports UI strings for translation.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The request.
+   *
+   * @return \Symfony\Component\HttpFoundation\JsonResponse
+   *   The response object.
+   */
+  public function exportLocale(Request $request) {
+    $langcode = $request->get('langcode');
+    $export = $this->argoService->exportLocale($langcode);
+
+    return new JsonResponse($export);
+  }
+
+  /**
+   * Translates UI strings into Drupal.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The request.
+   *
+   * @return \Symfony\Component\HttpFoundation\JsonResponse
+   *   The response object.
+   */
+  public function translateLocale(Request $request) {
+    $langcode = $request->get('langcode');
+    $translations = Json::decode($request->getContent());
+
+    try {
+      $this->argoService->translateLocale($langcode, $translations);
+    } catch (\Exception $e) {
+      \Drupal::logger('argo')->log(LogLevel::ERROR, $e->__toString());
+      return new JsonResponse([
+        'message' => $e->__toString(),
+      ],
+        Response::HTTP_INTERNAL_SERVER_ERROR);
+    }
+    return new JsonResponse();
   }
 
 }

--- a/src/Controller/ArgoController.php
+++ b/src/Controller/ArgoController.php
@@ -5,6 +5,7 @@ namespace Drupal\argo\Controller;
 use Drupal\argo\ArgoServiceInterface;
 use Drupal\Component\Serialization\Json;
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Logger\LoggerChannelInterface;
 use Psr\Log\LogLevel;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -24,13 +25,23 @@ class ArgoController extends ControllerBase {
   private $argoService;
 
   /**
+   * Logger service.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
+   */
+  private $logger;
+
+  /**
    * Argo constructor.
    *
    * @param \Drupal\argo\ArgoServiceInterface $argoService
    *   Argo service.
+   * @param \Drupal\Core\Logger\LoggerChannelInterface $logger
+   *   Argo logger.
    */
-  public function __construct(ArgoServiceInterface $argoService) {
+  public function __construct(ArgoServiceInterface $argoService, LoggerChannelInterface $logger) {
     $this->argoService = $argoService;
+    $this->logger = $logger;
   }
 
   /**
@@ -38,7 +49,8 @@ class ArgoController extends ControllerBase {
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('argo.service')
+      $container->get('argo.service'),
+      $container->get('logger.channel.argo')
     );
   }
 
@@ -77,7 +89,7 @@ class ArgoController extends ControllerBase {
     try {
       $this->argoService->translateConfig($langcode, $translations);
     } catch (\Exception $e) {
-      \Drupal::logger('argo')->log(LogLevel::ERROR, $e->__toString());
+      $this->logger->log(LogLevel::ERROR, $e->__toString());
       return new JsonResponse([
         'message' => $e->__toString(),
       ],
@@ -110,7 +122,7 @@ class ArgoController extends ControllerBase {
         $publishedOnlyBundles, $langcode);
     }
     catch (\Exception $e) {
-      \Drupal::logger('argo')->log(LogLevel::ERROR, $e->__toString());
+      $this->logger->log(LogLevel::ERROR, $e->__toString());
       return new JsonResponse([
         'message' => $e->__toString(),
       ],
@@ -181,7 +193,7 @@ class ArgoController extends ControllerBase {
       $this->argoService->translate($entityType, $uuid, $translation);
     }
     catch (\Exception $e) {
-      \Drupal::logger('argo')->log(LogLevel::ERROR, $e->__toString());
+      $this->logger->log(LogLevel::ERROR, $e->__toString());
       return new JsonResponse([
         'message' => $e->__toString(),
       ],
@@ -225,7 +237,7 @@ class ArgoController extends ControllerBase {
       $this->argoService->resetDeletionLog($deleted);
     }
     catch (\Exception $e) {
-      \Drupal::logger('argo')->log(LogLevel::ERROR, $e->__toString());
+      $this->logger->log(LogLevel::ERROR, $e->__toString());
       return new JsonResponse([
         'message' => $e->__toString(),
       ],
@@ -290,7 +302,7 @@ class ArgoController extends ControllerBase {
     try {
       $this->argoService->translateLocale($langcode, $translations);
     } catch (\Exception $e) {
-      \Drupal::logger('argo')->log(LogLevel::ERROR, $e->__toString());
+      $this->logger->log(LogLevel::ERROR, $e->__toString());
       return new JsonResponse([
         'message' => $e->__toString(),
       ],

--- a/src/Controller/ArgoController.php
+++ b/src/Controller/ArgoController.php
@@ -3,6 +3,7 @@
 namespace Drupal\argo\Controller;
 
 use Drupal\argo\ArgoServiceInterface;
+use Drupal\Component\Serialization\Json;
 use Drupal\Core\Controller\ControllerBase;
 use Psr\Log\LogLevel;
 use Symfony\Component\DependencyInjection\ContainerInterface;

--- a/src/Controller/ArgoController.php
+++ b/src/Controller/ArgoController.php
@@ -52,7 +52,10 @@ class ArgoController extends ControllerBase {
    */
   public function exportConfig(Request $request) {
     $langcode = $request->get('langcode');
-    $export = $this->argoService->exportConfig($langcode);
+    $include_translations = (bool) $request->query->get('include-translations', FALSE);
+    $export = $this->argoService->exportConfig($langcode, [
+      'include_translations' => $include_translations,
+    ]);
 
     return new JsonResponse($export);
   }
@@ -262,7 +265,10 @@ class ArgoController extends ControllerBase {
    */
   public function exportLocale(Request $request) {
     $langcode = $request->get('langcode');
-    $export = $this->argoService->exportLocale($langcode);
+    $include_translations = (bool) $request->query->get('include-translations', FALSE);
+    $export = $this->argoService->exportLocale($langcode, [
+      'include_translations' => $include_translations,
+    ]);
 
     return new JsonResponse($export);
   }

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Drupal\argo\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Settings for Argo module.
+ *
+ * @package Drupal\argo\Form
+ */
+class SettingsForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'argo.settings',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'argo_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form['#tree'] = TRUE;
+    $config = $this->config('argo.settings');
+
+    $config_keys = $config->get('config.translatable') ?? [];
+    $form['config']['translatable'] = [
+      '#type' => 'textarea',
+      '#rows' => 25,
+      '#title' => $this->t('Configuration entity names to enable Argo translation for.'),
+      '#description' => $this->t('One configuration name per line.<br />
+Examples: <ul>
+<li>views.settings</li>
+<li>webform.webform.* (will include all config entities that start with <em>webform.webform</em>)</li>
+</ul>'),
+      '#default_value' => implode(PHP_EOL, $config_keys),
+      '#size' => 60,
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $config = $this->config('argo.settings');
+    $values = $form_state->getValues();
+
+    $config_keys = preg_split("/[\r\n]+/", $values['config']['translatable']);
+    $config_keys = array_filter($config_keys);
+    $config_keys = array_values($config_keys);
+    $config->set('config.translatable', $config_keys);
+    $config->save();
+  }
+
+}

--- a/src/LocaleService.php
+++ b/src/LocaleService.php
@@ -14,7 +14,7 @@ class LocaleService {
    * Creates a new instance of the Argo locale translation service.
    */
   public function __construct(StringDatabaseStorage $stringStorage) {
-      $this->stringStorage = $stringStorage;
+    $this->stringStorage = $stringStorage;
   }
 
   /**
@@ -41,7 +41,7 @@ class LocaleService {
    */
   public function export(string $langcode, array $options = []) {
     // Merge in default options.
-    $options = ['include_translations' => TRUE] + $options;
+    $options += ['include_translations' => FALSE];
     $items = [];
     // @todo remove dependency on tableau_i18n_locale module. Maybe invoke an event/hook so that custom Tableau modules
     //   can hook into this?

--- a/src/LocaleService.php
+++ b/src/LocaleService.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Drupal\argo;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\StorageInterface;
+use Drupal\Core\Config\TypedConfigManagerInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\TypedData\TraversableTypedDataInterface;
+use Drupal\Core\TypedData\TypedDataInterface;
+use Drupal\locale\StringDatabaseStorage;
+use Drupal\tableau_i18n_locale\TableauLocaleStringDatabaseStorage;
+use Drupal\tableau_i18n_locale\TableauLocaleStringInterface;
+
+/**
+ * Handles locale export and translation.
+ */
+class LocaleService {
+
+  /**
+   * Creates a new instance of the Argo locale translation service.
+   */
+  public function __construct(StringDatabaseStorage $stringStorage) {
+      $this->stringStorage = $stringStorage;
+  }
+
+  /**
+   * Export a list of UI strings for translation.
+   *
+   * @param string $langcode
+   *   The langcode for which to export UI strings.
+   * @param array $options
+   *   Options to control the export.
+   *   [
+   *     'include_translations' => 'Whether or not to include already translated
+   *       values',
+   *   ]
+   *
+   * @return array
+   *   List of UI strings:
+   *    [
+   *     'string' => 'The original string value in the source language',
+   *     'translation' => 'A copy of the original string to be replaced by the
+   *       translator',
+   *     'context' => 'Context for the string.',
+   *     'url' => 'The url at which the string is found.',
+   *   ]
+   */
+  public function export(string $langcode, array $options = []) {
+    // Merge in default options.
+    $options = ['include_translations' => TRUE] + $options;
+    $items = [];
+    // @todo remove dependency on tableau_i18n_locale module. Maybe invoke an event/hook so that custom Tableau modules
+    //   can hook into this?
+    $strings = $this->stringStorage->getStrings([
+      'translated' => $options['include_translations'],
+      'visibility' => TableauLocaleStringInterface::EXTERNAL,
+    ]);
+
+    foreach ($strings as $string) {
+      // Try and retrieve metadata about the origins of this string.
+      $locations = $string->getLocations();
+      $url = '';
+      if (isset($locations['path'])) {
+        $url = implode(',', array_keys($locations['path']));
+      }
+      $items[] = [
+        'string' => $string->getString(),
+        'translation' => $string->getString(),
+        'context' => $string->context,
+        'url' => $url,
+      ];
+    }
+
+    return $items;
+  }
+
+  /**
+   * Imports a set of UI string translations.
+   *
+   * @param string $langcode
+   *   The langcode to import the translations for.
+   * @param array $translations
+   *   A list of translations of the format:
+   *   [
+   *     'string' => 'The original string value in the source language',
+   *     'translation' => 'The translated value of the string.',
+   *     'context' => 'Context for the string.',
+   *     'url' => 'The url at which the string is found.',
+   *   ]
+   */
+  public function import(string $langcode, array $translations) {
+    foreach ($translations as $translation) {
+        $string = $this->stringStorage->findString(['source' => $translation['string']]);
+        $translated_string = $this->stringStorage->createTranslation([
+            'lid' => $string->lid,
+            'language' => $langcode,
+            'translation' => $translation['translation'],
+        ])->save();
+    }
+  }
+
+}

--- a/src/LocaleService.php
+++ b/src/LocaleService.php
@@ -26,7 +26,7 @@ class LocaleService {
    *   [
    *     'include_translations' => 'Whether or not to include already translated
    *       values',
-   *   ]
+   *   ].
    *
    * @return array
    *   List of UI strings:
@@ -36,7 +36,7 @@ class LocaleService {
    *       translator',
    *     'context' => 'Context for the string.',
    *     'url' => 'The url at which the string is found.',
-   *   ]
+   *   ].
    */
   public function export(string $langcode, array $options = []) {
     // Merge in default options.
@@ -79,7 +79,7 @@ class LocaleService {
    *     'translation' => 'The translated value of the string.',
    *     'context' => 'Context for the string.',
    *     'url' => 'The url at which the string is found.',
-   *   ]
+   *   ].
    */
   public function import(string $langcode, array $translations) {
     foreach ($translations as $translation) {

--- a/src/LocaleService.php
+++ b/src/LocaleService.php
@@ -2,14 +2,7 @@
 
 namespace Drupal\argo;
 
-use Drupal\Core\Config\ConfigFactoryInterface;
-use Drupal\Core\Config\StorageInterface;
-use Drupal\Core\Config\TypedConfigManagerInterface;
-use Drupal\Core\Language\LanguageManagerInterface;
-use Drupal\Core\TypedData\TraversableTypedDataInterface;
-use Drupal\Core\TypedData\TypedDataInterface;
 use Drupal\locale\StringDatabaseStorage;
-use Drupal\tableau_i18n_locale\TableauLocaleStringDatabaseStorage;
 use Drupal\tableau_i18n_locale\TableauLocaleStringInterface;
 
 /**
@@ -91,12 +84,12 @@ class LocaleService {
    */
   public function import(string $langcode, array $translations) {
     foreach ($translations as $translation) {
-        $string = $this->stringStorage->findString(['source' => $translation['string']]);
-        $translated_string = $this->stringStorage->createTranslation([
-            'lid' => $string->lid,
-            'language' => $langcode,
-            'translation' => $translation['translation'],
-        ])->save();
+      $string = $this->stringStorage->findString(['source' => $translation['string']]);
+      $this->stringStorage->createTranslation([
+        'lid' => $string->lid,
+        'language' => $langcode,
+        'translation' => $translation['translation'],
+      ])->save();
     }
   }
 

--- a/src/LocaleService.php
+++ b/src/LocaleService.php
@@ -3,7 +3,6 @@
 namespace Drupal\argo;
 
 use Drupal\locale\StringDatabaseStorage;
-use Drupal\tableau_i18n_locale\TableauLocaleStringInterface;
 
 /**
  * Handles locale export and translation.
@@ -43,11 +42,11 @@ class LocaleService {
     // Merge in default options.
     $options += ['include_translations' => FALSE];
     $items = [];
-    // @todo remove dependency on tableau_i18n_locale module. Maybe invoke an event/hook so that custom Tableau modules
-    //   can hook into this?
+    // @todo remove dependency on tableau_i18n_locale module. Maybe invoke an
+    //   event/hook so that custom Tableau modules can hook into this?
     $strings = $this->stringStorage->getStrings([
       'translated' => $options['include_translations'],
-      'visibility' => TableauLocaleStringInterface::EXTERNAL,
+      'visibility' => 'external',
     ]);
 
     foreach ($strings as $string) {


### PR DESCRIPTION
## Release Notes
- New API endpoint to export config strings for translations (i.e. `/argo/config/{langcode}/export`). Additional option to include/exclude config values with existing translations can be controller via query parameter `include-translations=0/1`.
- New API endpoint to import config translations (i.e. `/argo/config/{langcode}/translate`).
- New API endpoint to export UI/locale strings for translations (i.e. `/argo/locale/{langcode}/export`). Additional option to include/exclude UI strings with existing translations can be controller via query parameter `include-translations=0/1`.
- New API endpoint to import UI/locale string translations (i.e. `/argo/locale/{langcode}/translate`).

## QA
1. Export config strings
http://argo-tableau-www.pantheonsite.io/argo/config/fr-FR/export
- [ ] Assert already translated config strings are excluded
http://argo-tableau-www.pantheonsite.io/argo/config/fr-FR/export?include-translations=1
- [ ] Assert the number is larger and all config strings - irregardless of their translations status - are included.

2. Import config translations
_Note: Use Postman for this_

Request: `POST`
Url: `http://argo-tableau-www.pantheonsite.io/argo/config/fr-FR/translation`
Body (JSON):
```
[
    {
        "key": "elements.phone.#title",
        "string": "Phone",
        "translation": "Phone FR",
        "context": "@todo",
        "url": "@todo",
        "config_id": "webform.webform.online_trial"
    },
    {
        "key": "handlers.tableau_online_trial.label",
        "string": "Tableau Online Trial",
        "translation": "Tableau Online Trial Fr-FR",
        "context": "@todo",
        "url": "@todo",
        "config_id": "webform.webform.online_trial"
    }
]
```
- [ ] Check the translations via http://argo-tableau-www.pantheonsite.io/admin/structure/webform/manage/online_trial/translate/fr-FR/edit

3. Export UI strings
 http://argo-tableau-www.pantheonsite.io/argo/locale/fr-FR/export
- [ ] Assert already translated UI strings are excluded
http://argo-tableau-www.pantheonsite.io/argo/locale/fr-FR/export?include-translations=1
- [ ] Assert the number is larger and all UI strings - irregardless of their translations status - are included.

4. Import UI string translations
Request: `POST`
Url: `http://argo-tableau-www.pantheonsite.io/argo/locale/fr-FR/translation`
Body (JSON):
```
[
    {
        "string": "additional",
        "translation": "additional FR",
        "context": "Aria Label",
        "url": "/es-es/learn/webinars/prep-conductor-making-data-prep-work-scale-your-organization"
    }
]
```
- [ ] Check the translation via http://argo-tableau-www.pantheonsite.io/admin/config/regional/translate

![Screen Shot 2021-04-02 at 11 26 22 AM](https://user-images.githubusercontent.com/8611594/113443169-47991100-93a6-11eb-86bc-7cf04412db22.png)
