### PR TITLE
Revision and correct translation metadata

### DIFF
--- a/argo.services.yml
+++ b/argo.services.yml
@@ -14,6 +14,7 @@ services:
       - '@entity_type.manager'
       - '@entity_field.manager'
       - '@content_moderation.moderation_information'
+      - '@content_translation.manager'
       - '@database'
   argo.config_service:
     class: Drupal\argo\ConfigService


### PR DESCRIPTION
## What / Why
Try to resolve a couple of issues in programmatic content entity translations.

- Retrieve the correct entity revision when translating content. In `ArgoService::translateContent`, there was a change to the call to `::loadEntity` which removed the `$revisionId` parameter, which would cause `::loadEntity` to try and look up the most recent revision. This may not be the correct revision we need. Instead we do a lookup for the `getLatestTranslationAffectedRevisionId` and load that revision.
  - The side effect of using the most recent revision was that translated content weren't marked as `revision_translation_affected` which is likely why imported content didn't show up in the revision list.
- Inject the Core content translation manager to instantiate a translation metadata wrapper similar to how Core's translation controller does it. We use this wrapper to set the correct source langcode and the changed time for the translation.
  - Without this change, we would have cases where a `fr-FR` translation created off of the `en-US` source has `und` (language undefined) assigned to its `content_translation_source` which looks like it can cause issues due to the bad association
  - This also properly sets the `changed` and `created` timestamps for the translation, before they all used the source entity's values.

Code is on the pre-prod env as of 2021-06-04