### PR TITLE
Fix bug introduced by v1.4.2 with using the most recent revision_translation_affected revision in the translation import

### DIFF
--- a/src/ArgoService.php
+++ b/src/ArgoService.php
@@ -161,7 +161,12 @@ class ArgoService implements ArgoServiceInterface {
    * {@inheritdoc}
    */
   public function exportContent(string $entityType, string $uuid, array $traversableEntityTypes, array $traversableContentTypes, int $revisionId = NULL) {
-    $entity = $this->loadEntity($entityType, $uuid, TRUE);
+    if (is_null($revisionId)) {
+      $entity = $this->loadEntity($entityType, $uuid, TRUE);
+    }
+    else {
+      $entity = $this->loadEntity($entityType, $uuid, FALSE, $revisionId);
+    }
     return $this->contentEntityExport->export($entity, $traversableEntityTypes, $traversableContentTypes);
   }
 


### PR DESCRIPTION
## What / Why
Fix issues related to:
- When translating/importing a new translation to Drupal. The loaded revision is the most recent `revision_translation_affected` revision of the entity due to a change in v1.4.2. When importing, we actually want the most recent revision of the entity.

## Dev details
Revise the `ArgoService::loadEntity` method:
- When exporting the content, we make loadEntity load the latest revision_translation_affected revision. This ensures that the exported content uses the revision with the intentional edit, mostly likely from the editor / admin UI.
- When programmatically translating the content, we make loadEntity load the most recent revision. This ensures that the new translation is added to the most recent revision which includes all other previously imported translation relationships.
- Add more clarifying comments on why we load which revision.