### PR TITLE
Add drupal/typed_data dependency to composer and info file

### DIFF
--- a/argo.info.yml
+++ b/argo.info.yml
@@ -4,4 +4,6 @@ package: Argo
 type: module
 core: 8.x
 core_version_requirement: ^8 || ^9
+dependencies:
+  - typed_data:typed_data
 php: 7.3

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,9 @@
   "keywords": ["Drupal"],
   "homepage": "https://github.com/spartansw/argo-drupal-module",
   "license": "GPL-2.0+",
+  "require": {
+    "drupal/typed_data": "^1.0"
+  },
   "minimum-stability": "dev",
   "authors": [],
   "support": {


### PR DESCRIPTION
The module uses `drupal/typed_data` services (`typed_data.data_fetcher`) but doesn't define any dependencies. If we perform a composer action that removes the `typed_data` module, then the service argo relies on will be unavailable.
