### PR TITLE
Update info and composer details for Drupal 10 compatibility

### DIFF
--- a/argo.info.yml
+++ b/argo.info.yml
@@ -2,9 +2,8 @@ name: Argo Connector
 description: Manage translations via Argo
 package: Argo
 type: module
-core: 8.x
-core_version_requirement: ^8 || ^9
-php: 7.3
+core_version_requirement: ^9 || ^10
+php: 8.1
 
 dependencies:
   - drupal:typed_data

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "source": "https://github.com/spartansw/argo-drupal-module"
   },
   "require": {
-    "drupal/core": "^8.8.2 || ^9",
+    "drupal/core": "^9 || ^10",
     "drupal/typed_data": "^1.0@beta"
   },
   "minimum-stability": "dev"


### PR DESCRIPTION
These are metadata changes to get argo compatible with Drupal 10

- Update core version requirements to `9 || 10`
- Up the PHP version requirement to 8.1